### PR TITLE
TASK: Try to avoid unsetting of __stopPrototypeInheritanceChain in fusionCache

### DIFF
--- a/Neos.Fusion/Classes/Core/Cache/ContentCache.php
+++ b/Neos.Fusion/Classes/Core/Cache/ContentCache.php
@@ -185,7 +185,6 @@ class ContentCache
     protected function renderContentCacheEntryIdentifier($fusionPath, array $cacheIdentifierValues)
     {
         ksort($cacheIdentifierValues);
-        unset($cacheIdentifierValues['__stopInheritanceChain']);
 
         $identifierSource = '';
         foreach ($cacheIdentifierValues as $key => $value) {

--- a/Neos.Fusion/Classes/Core/Parser.php
+++ b/Neos.Fusion/Classes/Core/Parser.php
@@ -199,7 +199,7 @@ class Parser implements ParserInterface
      *
      * @var array
      */
-    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__stopInheritanceChains', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
+    public static $reservedParseTreeKeys = ['__meta', '__prototypes', '__stopInheritanceChain', '__prototypeObjectName', '__prototypeChain', '__value', '__objectType', '__eelExpression'];
 
     /**
      * @Flow\Inject

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ContentCache.fusion
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Fusion/ContentCache.fusion
@@ -3,7 +3,6 @@ prototype(Neos.Fusion:Array).@class = 'Neos\\Fusion\\FusionObjects\\ArrayImpleme
 prototype(Neos.Fusion:Testing.Throwing).@class = 'Neos\\Fusion\\Tests\\Functional\\FusionObjects\\Fixtures\\FusionObjects\\ThrowingImplementation'
 
 prototype(Neos.Fusion:RawArray).@class = 'Neos\\Fusion\\FusionObjects\\RawArrayImplementation'
-prototype(Neos.Fusion:GlobalCacheIdentifiers) >
 prototype(Neos.Fusion:GlobalCacheIdentifiers) < prototype(Neos.Fusion:RawArray)
 
 contentCache.cachedSegment = Neos.Fusion:Array {


### PR DESCRIPTION
This was mainly added because in the fusionTests the line `prototype(Neos.Fusion:GlobalCacheIdentifiers) >` existed.
I doubt this is actually required and thus try to remove it.

